### PR TITLE
Added some missing contexts to ActivityPub activities

### DIFF
--- a/ap/service.go
+++ b/ap/service.go
@@ -183,7 +183,10 @@ func (s *Service) User(ctx context.Context, id string) (types.ApObject, error) {
 	}
 
 	return types.ApObject{
-		Context:     "https://www.w3.org/ns/activitystreams",
+		Context: []string{
+			"https://www.w3.org/ns/activitystreams",
+			"https://w3id.org/security/v1",
+		},
 		Type:        "Person",
 		ID:          "https://" + s.config.FQDN + "/ap/acct/" + id,
 		Inbox:       "https://" + s.config.FQDN + "/ap/acct/" + id + "/inbox",

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -472,7 +472,10 @@ func (s Service) MessageToNote(ctx context.Context, messageID string) (types.ApO
 	if document.Schema == world.MarkdownMessageSchema || document.Schema == world.MediaMessageSchema { // Note
 
 		return types.ApObject{
-			Context:        "https://www.w3.org/ns/activitystreams",
+			Context: []string{
+				"https://www.w3.org/ns/activitystreams",
+				"https://misskey-hub.net/ns#_misskey_content",
+			},
 			Type:           "Note",
 			ID:             "https://" + s.config.FQDN + "/ap/note/" + message.ID,
 			AttributedTo:   "https://" + s.config.FQDN + "/ap/acct/" + authorEntity.ID,
@@ -532,7 +535,10 @@ func (s Service) MessageToNote(ctx context.Context, messageID string) (types.ApO
 		}
 
 		return types.ApObject{
-			Context:        "https://www.w3.org/ns/activitystreams",
+			Context: []string{
+				"https://www.w3.org/ns/activitystreams",
+				"https://misskey-hub.net/ns#_misskey_content",
+			},
 			Type:           "Note",
 			ID:             "https://" + s.config.FQDN + "/ap/note/" + message.ID,
 			AttributedTo:   "https://" + s.config.FQDN + "/ap/acct/" + authorEntity.ID,
@@ -591,7 +597,10 @@ func (s Service) MessageToNote(ctx context.Context, messageID string) (types.ApO
 		}
 
 		return types.ApObject{
-			Context:        "https://www.w3.org/ns/activitystreams",
+			Context: []string{
+				"https://www.w3.org/ns/activitystreams",
+				"https://misskey-hub.net/ns#_misskey_content",
+			},
 			Type:           "Note",
 			ID:             "https://" + s.config.FQDN + "/ap/note/" + message.ID,
 			AttributedTo:   "https://" + s.config.FQDN + "/ap/acct/" + authorEntity.ID,


### PR DESCRIPTION
I have added a context to the activity which contains the following fields

```
"https://misskey-hub.net/ns#_misskey_content" (_misskey_content)
"https://w3id.org/security/v1" (publicKey etc.)
```

Required for federation with some software such as Iceshrimp.net.

https://chat.iceshrimp.dev/#narrow/stream/6-support/topic/.5B.2ENET.5D.20Inbox.2FDeliver.20failed.2E/near/51103